### PR TITLE
#45 - Тестирование API

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -1,5 +1,5 @@
-persistent = false
-app-host = "localhost"
+persistent = true
+app-host = "172.18.1.2"
 app-port = "9000"
 db-host = "172.18.1.10"
 db-port = "5432"

--- a/src/main/scala/api/handlers/IoDbPhoneBookHandler.scala
+++ b/src/main/scala/api/handlers/IoDbPhoneBookHandler.scala
@@ -170,4 +170,20 @@ class IoDbPhoneBookHandler(host: String, port: String, db: String,
     }
   }
 
+
+
+  /** Для тестов */
+  def resetTable(): Unit = {
+    sql"DROP TABLE IF EXISTS phonebook"
+      .update
+      .run
+      .transact(tr)
+      .unsafeRunSync()
+    sql"CREATE TABLE IF NOT EXISTS phonebook (id SERIAL PRIMARY KEY,name VARCHAR(100) NOT NULL,phoneNumber VARCHAR(100) NOT NULL);"
+      .update
+      .run
+      .transact(tr)
+      .unsafeRunSync()
+  }
+
 }

--- a/src/main/scala/collection/IdGenerator.scala
+++ b/src/main/scala/collection/IdGenerator.scala
@@ -6,6 +6,7 @@ object IdGenerator {
   /** Генератор уникальных ID. Основан на AtomicLong.
    *  TODO: Переписать функционально
    */
-  val id: AtomicLong = new AtomicLong()
+  val id: AtomicLong = new AtomicLong(1)  // PostgreSQL начинает с 1, для единообразия будем тоже
   def next(): Long = id.getAndIncrement()
+  def reset(): Unit = id.set(1)  // для тестов API
 }

--- a/src/test/scala/api/ApiSuit.scala
+++ b/src/test/scala/api/ApiSuit.scala
@@ -1,0 +1,205 @@
+package api
+import cats.effect._
+import io.circe.Json
+import org.junit.Test
+import org.junit.Assert._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import api.handlers._
+import share.ContactModel._
+import org.http4s.circe._
+import io.circe.syntax._
+import org.http4s.headers.`Content-Type`
+import share.PhoneBookModel.PhoneBookModel
+import collection.IdGenerator
+
+
+class ApiSuit {
+
+  /** Апи для тестирования в каждом тесте новое со сбросом счётчика/базы данных*/
+  def api() = {
+
+    IdGenerator.reset()
+    val handler = new IoCollectionPhoneBookHandler()
+
+    /*val handler = new IoDbPhoneBookHandler("localhost", "5432", "postgres", "postgres", "P@ssw0rd")
+    handler.resetTable()*/
+
+    new Api(handler)
+  }
+
+
+  @Test def `Test index service must return Ok`: Unit = {
+    val request = Request[IO](GET, uri"/")
+    val io = api().indexCall.orNotFound.run(request)
+    val response = io.unsafeRunSync
+    assertEquals(Ok, response.status)
+  }
+
+  @Test def `Get 404 on invalid request`: Unit = {
+    val request = Request[IO](GET, uri"/help_me_please")
+    val io = api().indexCall.orNotFound.run(request)
+    val response = io.unsafeRunSync
+    assertEquals(NotFound, response.status)
+  }
+
+
+  @Test def `Get added contact`: Unit = {
+    val req = ContactRequest("1", "2").asJson
+    val exp = PhoneBookModel(List(Contact(1,"1","2"))).asJson
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    val io = api().addContact.orNotFound.run(request)
+    val response = io.flatMap(_.as[Json]).unsafeRunSync()
+    assertEquals(exp, response)
+  }
+
+  @Test def `Get added contact from listContacts`: Unit = {
+    val req = ContactRequest("1", "2").asJson
+    val exp = PhoneBookModel(List(Contact(1,"1","2"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](GET, uri"/contacts")
+    val io2 = persist.listContacts.orNotFound.run(request2)
+    val response2 = io2.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response2)
+  }
+
+  @Test def `Find contact from findName`: Unit = {
+    val req = ContactRequest("John", "123").asJson
+    val exp = PhoneBookModel(List(Contact(1, "John", "123"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](GET, uri"/contact/findByName?name=Jo")
+    val io2 = persist.findContactsByName.orNotFound.run(request2)
+    val response2 = io2.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response2)
+  }
+
+
+  @Test def `Find two contacts from findName`: Unit = {
+    val exp = PhoneBookModel(List(Contact(2, "Josh", "432432"), Contact(1, "John", "123"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(ContactRequest("John", "123").asJson)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](POST, uri"/contact").withEntity(ContactRequest("Josh", "432432").asJson)
+    persist.addContact.orNotFound.run(request2).unsafeRunSync()
+
+
+    val request3 = Request[IO](GET, uri"/contact/findByName?name=Jo")
+    val io3 = persist.findContactsByName.orNotFound.run(request3)
+    val response3 = io3.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response3)
+  }
+
+
+
+
+  @Test def `Find contact from findPhone`: Unit = {
+    val req = ContactRequest("John", "123").asJson
+    val exp = PhoneBookModel(List(Contact(1, "John", "123"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](GET, uri"/contact/findByPhone?phone=12")
+    val io2 = persist.findContactsByPhone.orNotFound.run(request2)
+    val response2 = io2.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response2)
+  }
+
+  @Test def `Find two contacts from findPhone`: Unit = {
+    val exp = PhoneBookModel(List(Contact(2, "Josh", "122432"), Contact(1, "John", "123"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(ContactRequest("John", "123").asJson)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](POST, uri"/contact").withEntity(ContactRequest("Josh", "122432").asJson)
+    persist.addContact.orNotFound.run(request2).unsafeRunSync()
+
+
+    val request3 = Request[IO](GET, uri"/contact/findByPhone?phone=12")
+    val io3 = persist.findContactsByPhone.orNotFound.run(request3)
+    val response3 = io3.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response3)
+  }
+
+
+  @Test def `Find contact from id`: Unit = {
+    val req = ContactRequest("John", "123").asJson
+    val exp = Contact(1, "John", "123").asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](GET, uri"/contact/1")
+    val io2 = persist.getContactById.orNotFound.run(request2)
+    val response2 = io2.flatMap(_.as[Json]).unsafeRunSync()
+
+    assertEquals(exp, response2)
+  }
+
+
+  @Test def `Update contact by id`: Unit = {
+    val req = ContactRequest("John", "123").asJson
+    val exp = PhoneBookModel(List(Contact(1, "Johnny", "321"))).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val new_req = ContactRequest("Johnny", "321").asJson
+    val request2 = Request[IO](PUT, uri"/contact/1").withEntity(new_req)
+    persist.updateContact.orNotFound.run(request2).unsafeRunSync()
+
+
+    val request3 = Request[IO](GET, uri"/contacts")
+    val io3 = persist.listContacts.orNotFound.run(request3)
+    val response3 = io3.flatMap(_.as[Json]).unsafeRunSync()
+    assertEquals(exp, response3)
+  }
+
+  @Test def `Delete contact by id`: Unit = {
+    val req = ContactRequest("John", "123").asJson
+    val exp = PhoneBookModel(List()).asJson
+
+    val persist = api()
+
+    val request = Request[IO](POST, uri"/contact").withEntity(req)
+    persist.addContact.orNotFound.run(request).unsafeRunSync()
+
+    val request2 = Request[IO](DELETE, uri"/contact/1")
+    persist.deleteContact.orNotFound.run(request2).unsafeRunSync()
+
+    val request3 = Request[IO](GET, uri"/contacts")
+    val io3 = persist.listContacts.orNotFound.run(request3)
+    val response3 = io3.flatMap(_.as[Json]).unsafeRunSync()
+    assertEquals(exp, response3)
+  }
+
+}

--- a/src/test/scala/collection/CollectionPhoneBookSuit.scala
+++ b/src/test/scala/collection/CollectionPhoneBookSuit.scala
@@ -22,7 +22,7 @@ class CollectionPhoneBookSuit {
     val name = "James Sunderland"
     val phone = "883-223"
     val result = addContact(createBook(), ContactRequest(name, phone))
-    assertEquals(Right(List(Contact(0, name, phone))), result)
+    assertEquals(Right(List(Contact(1, name, phone))), result)
   }
 
 


### PR DESCRIPTION
- Добавил тесты API
- Тесты возможно переключать с хендлера БД на хендлер Коллекции
- Добавил методы ресета счётчика ID и таблицы БД
- Теперь счётчик ID для коллекции начинается с 1, как у PostgreSQL